### PR TITLE
Polylang fix

### DIFF
--- a/enhanced-media-library.php
+++ b/enhanced-media-library.php
@@ -216,7 +216,7 @@ if ( ! function_exists( 'wpuxss_eml_on_wp_loaded' ) ) {
         global $wp_taxonomies;
 
         $wpuxss_eml_taxonomies = get_option( 'wpuxss_eml_taxonomies', array() );
-        $taxonomies = get_taxonomies( array(), 'object' );
+        $taxonomies = get_taxonomies( array( 'show_ui' => true, 'public' => true ), 'objects' );
 
 
         // discover 'foreign' taxonomies


### PR DESCRIPTION
Korjaa Polylangin kielien linkityksen hajoamisen. Koodinpätkä kopioitu Enhanced Media Libraryn 3.0.beta2-29 versiosta, jossa ongelma on korjattu: https://github.com/webbistro/enhanced-media-library/tree/v3.0.beta2-29

